### PR TITLE
feat: add worktree cleanup on ticket delete

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,17 +8,11 @@ import (
 
 // Config holds the global application configuration
 type Config struct {
-	// Default settings for new boards
-	Defaults BoardSettings `json:"defaults"`
-
-	// Agent configurations by name
-	Agents map[string]AgentConfig `json:"agents"`
-
-	// UI preferences
-	UI UIConfig `json:"ui"`
-
-	// Custom keybindings
-	Keys map[string]string `json:"keys,omitempty"`
+	Defaults BoardSettings          `json:"defaults"`
+	Agents   map[string]AgentConfig `json:"agents"`
+	UI       UIConfig               `json:"ui"`
+	Cleanup  CleanupSettings        `json:"cleanup"`
+	Keys     map[string]string      `json:"keys,omitempty"`
 }
 
 // BoardSettings contains default settings for boards
@@ -49,6 +43,13 @@ type UIConfig struct {
 	RefreshInterval int    `json:"refresh_interval"`
 	ColumnWidth     int    `json:"column_width"`
 	TicketHeight    int    `json:"ticket_height"`
+}
+
+// CleanupSettings controls cleanup behavior when deleting tickets
+type CleanupSettings struct {
+	DeleteWorktree       bool `json:"delete_worktree"`        // Remove git worktree on ticket delete
+	DeleteBranch         bool `json:"delete_branch"`          // Delete git branch after worktree removal
+	ForceWorktreeRemoval bool `json:"force_worktree_removal"` // Force removal even with uncommitted changes
 }
 
 // DefaultConfig returns the default configuration
@@ -93,6 +94,11 @@ func DefaultConfig() *Config {
 			RefreshInterval: 5,
 			ColumnWidth:     40,
 			TicketHeight:    4,
+		},
+		Cleanup: CleanupSettings{
+			DeleteWorktree:       true,
+			DeleteBranch:         false,
+			ForceWorktreeRemoval: false,
 		},
 	}
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -153,6 +153,19 @@ func (m *WorktreeManager) DeleteBranch(branchName string) error {
 	return nil
 }
 
+// HasUncommittedChanges checks if the worktree has uncommitted changes
+func (m *WorktreeManager) HasUncommittedChanges(worktreePath string) (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	cmd.Dir = worktreePath
+
+	output, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to check git status: %w", err)
+	}
+
+	return len(strings.TrimSpace(string(output))) > 0, nil
+}
+
 // sanitizeBranchName converts a branch name to a safe directory name
 func sanitizeBranchName(name string) string {
 	// Remove common prefixes


### PR DESCRIPTION
Closes #8

When deleting a ticket, cleans up associated resources:
- Stops running agent pane
- Removes git worktree (configurable)
- Optionally deletes git branch

If the worktree has uncommitted changes and force removal is disabled, prompts for confirmation before proceeding.

New config options in `cleanup` section control behavior.