### PR TITLE
fix: enable scroll and pass Tab to agent sessions

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -622,8 +622,7 @@ func (m *Model) renderAgentView() string {
 
 	keyStyle := lipgloss.NewStyle().Foreground(colorTeal)
 	hints := paneIndicator + "  " +
-		keyStyle.Render("Ctrl+g") + dimStyle.Render(" Board") + "  " +
-		keyStyle.Render("Tab") + dimStyle.Render(" Next")
+		keyStyle.Render("Ctrl+g") + dimStyle.Render(" Board")
 
 	spacing := m.width - lipgloss.Width(header) - lipgloss.Width(hints)
 	if spacing < 0 {


### PR DESCRIPTION
Agent sessions now behave more natively:

- Mouse wheel scrolls through terminal history
- Tab key passes through to agents (for plan mode cycling, etc.)
- Ctrl+g remains the only escape key back to board view