### PR TITLE
feat: inject ticket context into agent sessions

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/techdufus/openkanban/internal/board"
+)
+
+type ContextData struct {
+	Title        string
+	Description  string
+	BranchName   string
+	BaseBranch   string
+	TicketID     string
+	Status       string
+	WorktreePath string
+}
+
+func BuildContextPrompt(promptTemplate string, ticket *board.Ticket) string {
+	if promptTemplate == "" {
+		return ""
+	}
+
+	data := ContextData{
+		Title:        ticket.Title,
+		Description:  ticket.Description,
+		BranchName:   ticket.BranchName,
+		BaseBranch:   ticket.BaseBranch,
+		TicketID:     string(ticket.ID),
+		Status:       string(ticket.Status),
+		WorktreePath: ticket.WorktreePath,
+	}
+
+	tmpl, err := template.New("prompt").Parse(promptTemplate)
+	if err != nil {
+		return buildFallbackPrompt(ticket)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return buildFallbackPrompt(ticket)
+	}
+
+	return buf.String()
+}
+
+func buildFallbackPrompt(ticket *board.Ticket) string {
+	var sb strings.Builder
+	sb.WriteString("Task: ")
+	sb.WriteString(ticket.Title)
+	if ticket.Description != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(ticket.Description)
+	}
+	return sb.String()
+}
+
+func ShouldInjectContext(ticket *board.Ticket) bool {
+	return ticket.AgentSpawnedAt == nil
+}

--- a/internal/terminal/pane.go
+++ b/internal/terminal/pane.go
@@ -188,7 +188,6 @@ func (p *Pane) Start(command string, args ...string) tea.Cmd {
 	}
 }
 
-// Stop terminates the running process
 func (p *Pane) Stop() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -201,6 +200,18 @@ func (p *Pane) Stop() error {
 	}
 	p.running = false
 	return nil
+}
+
+var ErrPaneNotRunning = fmt.Errorf("pane is not running")
+
+func (p *Pane) WriteInput(data []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.running || p.pty == nil {
+		return 0, ErrPaneNotRunning
+	}
+	return p.pty.Write(data)
 }
 
 // readOutput returns a Cmd that reads from the PTY

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1119,29 +1120,31 @@ func (m *Model) spawnAgent() (tea.Model, tea.Cmd) {
 	ticket.AgentType = agentType
 	ticket.AgentStatus = board.AgentIdle
 
-	isResume := ticket.AgentSpawnedAt != nil
-	args := m.buildAgentArgs(agentCfg, ticket)
+	isNewSession := agent.ShouldInjectContext(ticket)
+	args := m.buildAgentArgs(agentCfg, ticket, isNewSession)
 
-	if !isResume {
+	if isNewSession {
 		now := time.Now()
 		ticket.AgentSpawnedAt = &now
 	}
 
 	m.saveBoard()
 
-	if isResume {
-		m.notify("Resuming " + agentType)
-	} else {
+	if isNewSession {
 		m.notify("Starting " + agentType)
+	} else {
+		m.notify("Resuming " + agentType)
 	}
 
 	m.mode = ModeAgentView
 	m.focusedPane = ticket.ID
 
+	m.debugLogSpawn(agentCfg.Command, args, ticket)
+
 	return m, pane.Start(agentCfg.Command, args...)
 }
 
-func (m *Model) buildAgentArgs(cfg config.AgentConfig, ticket *board.Ticket) []string {
+func (m *Model) buildAgentArgs(cfg config.AgentConfig, ticket *board.Ticket, isNewSession bool) []string {
 	args := make([]string, len(cfg.Args))
 	copy(args, cfg.Args)
 
@@ -1150,16 +1153,28 @@ func (m *Model) buildAgentArgs(cfg config.AgentConfig, ticket *board.Ticket) []s
 		agentType = filepath.Base(agentType)
 	}
 
-	hasSession := ticket.AgentSpawnedAt != nil
+	promptTemplate := m.config.GetEffectiveInitPrompt(agentType)
 
 	switch agentType {
 	case "claude":
-		if hasSession && !containsFlag(args, "--continue", "-c") {
-			args = append(args, "--continue")
+		if isNewSession && promptTemplate != "" {
+			prompt := agent.BuildContextPrompt(promptTemplate, ticket)
+			if prompt != "" {
+				args = append(args, "--append-system-prompt", prompt)
+			}
+		} else if !isNewSession {
+			if !containsFlag(args, "--continue", "-c") {
+				args = append(args, "--continue")
+			}
 		}
 	case "opencode":
 		args = append([]string{ticket.WorktreePath}, args...)
-		if hasSession {
+		if isNewSession && promptTemplate != "" {
+			prompt := agent.BuildContextPrompt(promptTemplate, ticket)
+			if prompt != "" {
+				args = append(args, "-p", prompt)
+			}
+		} else if !isNewSession {
 			if sessionID := agent.FindOpencodeSession(ticket.WorktreePath); sessionID != "" {
 				args = append(args, "--session", sessionID)
 			}
@@ -1178,6 +1193,30 @@ func containsFlag(args []string, flags ...string) bool {
 		}
 	}
 	return false
+}
+
+func (m *Model) debugLogSpawn(command string, args []string, ticket *board.Ticket) {
+	debugPath := filepath.Join(ticket.WorktreePath, ".openkanban-debug.log")
+	f, err := os.Create(debugPath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "=== OpenKanban Agent Spawn Debug ===\n")
+	fmt.Fprintf(f, "Time: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(f, "Ticket ID: %s\n", ticket.ID)
+	fmt.Fprintf(f, "Ticket Title: %s\n", ticket.Title)
+	fmt.Fprintf(f, "Ticket Description:\n%s\n", ticket.Description)
+	fmt.Fprintf(f, "AgentSpawnedAt: %v\n", ticket.AgentSpawnedAt)
+	fmt.Fprintf(f, "\n=== Command ===\n")
+	fmt.Fprintf(f, "Command: %s\n", command)
+	fmt.Fprintf(f, "Args count: %d\n", len(args))
+	for i, arg := range args {
+		fmt.Fprintf(f, "Arg[%d]: %s\n", i, arg)
+	}
+	fmt.Fprintf(f, "\n=== Full Command ===\n")
+	fmt.Fprintf(f, "%s %s\n", command, strings.Join(args, " "))
 }
 
 func (m *Model) stopAgent() (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary
- New agent sessions now automatically receive ticket context (title, description, branch info)
- Configurable prompts via global `defaults.init_prompt` or per-agent `agents.<name>.init_prompt`
- Supports Go template variables: `{{.Title}}`, `{{.Description}}`, `{{.BranchName}}`, `{{.BaseBranch}}`, `{{.TicketID}}`, `{{.Status}}`, `{{.WorktreePath}}`

Context is injected via CLI args:
- claude: `--append-system-prompt` (hidden system context)
- opencode: `-p` flag (visible first message)