### PR TITLE
fix: add keyboard scrolling support to agent chat view

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -45,6 +45,8 @@ const (
 	formFieldTitle       = 0
 	formFieldDescription = 1
 	formFieldBranch      = 2
+
+	defaultScrollback = 10000
 )
 
 // Model is the main Bubbletea model
@@ -515,6 +517,35 @@ func (m *Model) handleAgentViewMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if !ok {
 		m.mode = ModeNormal
 		m.focusedPane = ""
+		return m, nil
+	}
+
+	pageScrollAmount := m.height - 4
+	if pageScrollAmount < 1 {
+		pageScrollAmount = 10
+	}
+
+	switch msg.Type {
+	case tea.KeyPgUp:
+		pane.ScrollUp(pageScrollAmount)
+		return m, nil
+	case tea.KeyPgDown:
+		pane.ScrollDown(pageScrollAmount)
+		return m, nil
+	case tea.KeyHome:
+		pane.ScrollUp(defaultScrollback)
+		return m, nil
+	case tea.KeyEnd:
+		pane.ScrollToBottom()
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "shift+up":
+		pane.ScrollUp(1)
+		return m, nil
+	case "shift+down":
+		pane.ScrollDown(1)
 		return m, nil
 	}
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -485,12 +485,16 @@ func (m *Model) renderHelp() string {
 		"  " + keyStyle.Render("j/k") + descStyle.Render("   Move between tickets  ") + keyStyle.Render("e") + descStyle.Render("       Edit ticket") + "\n" +
 		"  " + keyStyle.Render("g") + descStyle.Render("     Go to first ticket    ") + keyStyle.Render("d") + descStyle.Render("       Delete ticket") + "\n" +
 		"  " + keyStyle.Render("G") + descStyle.Render("     Go to last ticket     ") + keyStyle.Render("Space") + descStyle.Render("   Quick move") + "\n\n" +
-		"  " + keyStyle.Render("Agent") + "                         " + keyStyle.Render("Other") + "\n" +
+		"  " + keyStyle.Render("Agent") + "                         " + keyStyle.Render("Agent Scroll") + "\n" +
 		"  " + sep + "\n" +
-		"  " + keyStyle.Render("s") + descStyle.Render("     Spawn agent           ") + keyStyle.Render("O") + descStyle.Render("       Board settings") + "\n" +
-		"  " + keyStyle.Render("S") + descStyle.Render("     Stop agent            ") + keyStyle.Render("?") + descStyle.Render("       Toggle help") + "\n" +
-		"  " + keyStyle.Render("Enter") + descStyle.Render(" Attach to agent       ") + keyStyle.Render("q") + descStyle.Render("       Quit") + "\n" +
-		"  " + keyStyle.Render("Ctrl+g") + descStyle.Render(" Exit agent view") + "\n\n" +
+		"  " + keyStyle.Render("s") + descStyle.Render("     Spawn agent           ") + keyStyle.Render("PgUp") + descStyle.Render("    Scroll up page") + "\n" +
+		"  " + keyStyle.Render("S") + descStyle.Render("     Stop agent            ") + keyStyle.Render("PgDn") + descStyle.Render("    Scroll down page") + "\n" +
+		"  " + keyStyle.Render("Enter") + descStyle.Render(" Attach to agent       ") + keyStyle.Render("Home") + descStyle.Render("    Scroll to top") + "\n" +
+		"  " + keyStyle.Render("Ctrl+g") + descStyle.Render(" Exit agent view       ") + keyStyle.Render("End") + descStyle.Render("     Scroll to bottom") + "\n\n" +
+		"  " + keyStyle.Render("Other") + "\n" +
+		"  " + sep + "\n" +
+		"  " + keyStyle.Render("O") + descStyle.Render("     Board settings        ") + keyStyle.Render("?") + descStyle.Render("       Toggle help") + "\n" +
+		"  " + keyStyle.Render("q") + descStyle.Render("     Quit") + "\n\n" +
 		"  " + dimStyle.Render("Press any key to close")
 
 	return lipgloss.NewStyle().
@@ -713,6 +717,7 @@ func (m *Model) renderAgentView() string {
 
 	keyStyle := lipgloss.NewStyle().Foreground(colorTeal)
 	hints := paneIndicator + "  " +
+		keyStyle.Render("PgUp/PgDn") + dimStyle.Render(" Scroll  ") +
 		keyStyle.Render("Ctrl+g") + dimStyle.Render(" Board")
 
 	spacing := m.width - lipgloss.Width(header) - lipgloss.Width(hints)


### PR DESCRIPTION
## Summary

- Adds keyboard scrolling support in agent chat view (PageUp/PageDown, Home/End, Shift+Up/Down)
- Previously keyboard input was only forwarded to the PTY, with no way to scroll history
- Mouse wheel scrolling was already working, this adds the missing keyboard support