### PR TITLE
fix: capture output lines directly for reliable scrollback

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -495,6 +495,7 @@ func (m *Model) renderHelp() string {
 		"  " + sep + "\n" +
 		"  " + keyStyle.Render("O") + descStyle.Render("     Board settings        ") + keyStyle.Render("?") + descStyle.Render("       Toggle help") + "\n" +
 		"  " + keyStyle.Render("q") + descStyle.Render("     Quit") + "\n\n" +
+		"  " + dimStyle.Render("Tip: Hold Shift to select text in agent view") + "\n\n" +
 		"  " + dimStyle.Render("Press any key to close")
 
 	return lipgloss.NewStyle().


### PR DESCRIPTION
## Summary
- Fixed scrollback capture mechanism that was broken for AI agent output
- The old approach detected scrollback by checking if vt10x's top line changed, which failed when agents use cursor positioning and screen clears
- Now parses output stream for newlines directly to reliably capture all lines
- Added help tip about Shift+click for native text selection