### PR TITLE
feat: worktrees share parent repo board

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -130,7 +130,9 @@ func findBoard(cfg *config.Config, path string) (*board.Board, error) {
 	}
 
 	// If path is a repo path, find matching board
+	// Resolve worktree to main repo so worktrees share the same board
 	absPath, _ := filepath.Abs(path)
+	absPath = git.ResolveMainRepo(absPath)
 	entries, _ := os.ReadDir(dir)
 	for _, entry := range entries {
 		if filepath.Ext(entry.Name()) == ".json" {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -178,3 +178,33 @@ func sanitizeBranchName(name string) string {
 
 	return name
 }
+
+func ResolveMainRepo(path string) string {
+	gitPath := filepath.Join(path, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return path
+	}
+
+	if info.IsDir() {
+		return path
+	}
+
+	content, err := os.ReadFile(gitPath)
+	if err != nil {
+		return path
+	}
+
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return path
+	}
+
+	gitdir := strings.TrimPrefix(line, "gitdir: ")
+
+	if idx := strings.Index(gitdir, "/.git/worktrees/"); idx != -1 {
+		return gitdir[:idx]
+	}
+
+	return path
+}


### PR DESCRIPTION
## Summary
- Add `ResolveMainRepo()` that detects git worktrees and resolves to main repo path
- Update `findBoard()` to use resolution, so worktrees find the same board as their parent

Running openkanban from a worktree now uses the parent repo's board instead of failing or creating a separate board.

Closes #37