### PR TITLE
refactor: project-centric architecture with global ticket view

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	cfgFile   string
-	boardPath string
+	cfgFile     string
+	projectPath string
 )
 
 var rootCmd = &cobra.Command{
@@ -29,13 +29,13 @@ for safe parallel development.`,
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		bp := boardPath
-		if bp == "" {
+		pp := projectPath
+		if pp == "" {
 			cwd, _ := os.Getwd()
-			bp = cwd
+			pp = cwd
 		}
 
-		return app.Run(cfg, bp)
+		return app.Run(cfg, pp)
 	},
 }
 
@@ -45,7 +45,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.config/openkanban/config.json)")
-	rootCmd.PersistentFlags().StringVarP(&boardPath, "board", "b", "", "board or repository path")
+	rootCmd.PersistentFlags().StringVarP(&projectPath, "project", "p", "", "project or repository path")
 
 	rootCmd.AddCommand(newCmd)
 	rootCmd.AddCommand(listCmd)
@@ -53,7 +53,7 @@ func init() {
 
 var newCmd = &cobra.Command{
 	Use:   "new [name]",
-	Short: "Create a new board",
+	Short: "Create a new project",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := "default"
@@ -66,7 +66,7 @@ var newCmd = &cobra.Command{
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		repoPath := boardPath
+		repoPath := projectPath
 		if repoPath == "" {
 			repoPath, _ = os.Getwd()
 		}
@@ -76,19 +76,14 @@ var newCmd = &cobra.Command{
 			return fmt.Errorf("failed to resolve path: %w", err)
 		}
 
-		return app.CreateBoard(cfg, name, repoPath)
+		return app.CreateProject(cfg, name, repoPath)
 	},
 }
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all boards",
+	Short: "List all projects",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load(cfgFile)
-		if err != nil {
-			return fmt.Errorf("failed to load config: %w", err)
-		}
-
-		return app.ListBoards(cfg)
+		return app.ListProjects()
 	},
 }

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -1,9 +1,6 @@
 package board
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -43,15 +40,12 @@ func Slugify(s string, maxLen int) string {
 	return slug
 }
 
-// TicketID is a unique identifier for a ticket
 type TicketID string
 
-// NewTicketID generates a new unique ticket ID
 func NewTicketID() TicketID {
 	return TicketID(uuid.New().String())
 }
 
-// TicketStatus represents the workflow status of a ticket
 type TicketStatus string
 
 const (
@@ -61,7 +55,6 @@ const (
 	StatusArchived   TicketStatus = "archived"
 )
 
-// AgentStatus represents the current state of an AI agent
 type AgentStatus string
 
 const (
@@ -73,40 +66,36 @@ const (
 	AgentError     AgentStatus = "error"
 )
 
-// Ticket represents a unit of work
 type Ticket struct {
 	ID          TicketID     `json:"id"`
+	ProjectID   string       `json:"project_id"`
 	Title       string       `json:"title"`
 	Description string       `json:"description,omitempty"`
 	Status      TicketStatus `json:"status"`
 
-	// Git integration
 	WorktreePath string `json:"worktree_path,omitempty"`
 	BranchName   string `json:"branch_name,omitempty"`
 	BaseBranch   string `json:"base_branch,omitempty"`
 
-	// Agent integration
 	AgentType      string      `json:"agent_type,omitempty"`
 	AgentStatus    AgentStatus `json:"agent_status"`
 	AgentSpawnedAt *time.Time  `json:"agent_spawned_at,omitempty"`
 
-	// Timestamps
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 	StartedAt   *time.Time `json:"started_at,omitempty"`
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
 
-	// Metadata
 	Labels   []string          `json:"labels,omitempty"`
 	Priority int               `json:"priority,omitempty"`
 	Meta     map[string]string `json:"meta,omitempty"`
 }
 
-// NewTicket creates a new ticket with defaults
-func NewTicket(title string) *Ticket {
+func NewTicket(title, projectID string) *Ticket {
 	now := time.Now()
 	return &Ticket{
 		ID:          NewTicketID(),
+		ProjectID:   projectID,
 		Title:       title,
 		Status:      StatusBacklog,
 		AgentStatus: AgentNone,
@@ -118,7 +107,23 @@ func NewTicket(title string) *Ticket {
 	}
 }
 
-// Column represents a kanban column
+func (t *Ticket) Touch() {
+	t.UpdatedAt = time.Now()
+}
+
+func (t *Ticket) SetStatus(status TicketStatus) {
+	now := time.Now()
+	t.Status = status
+	t.UpdatedAt = now
+
+	switch status {
+	case StatusInProgress:
+		t.StartedAt = &now
+	case StatusDone:
+		t.CompletedAt = &now
+	}
+}
+
 type Column struct {
 	ID     string       `json:"id"`
 	Name   string       `json:"name"`
@@ -127,108 +132,16 @@ type Column struct {
 	Limit  int          `json:"limit"`
 }
 
-// BoardSettings contains board-specific settings
-type BoardSettings struct {
-	DefaultAgent     string `json:"default_agent"`
-	WorktreeBase     string `json:"worktree_base"`
-	AutoSpawnAgent   bool   `json:"auto_spawn_agent"`
-	AutoCreateBranch bool   `json:"auto_create_branch"`
-	BranchPrefix     string `json:"branch_prefix"`
-	BranchNaming     string `json:"branch_naming"`   // "template" | "ai" | "prompt"
-	BranchTemplate   string `json:"branch_template"` // e.g., "{prefix}{slug}"
-	SlugMaxLength    int    `json:"slug_max_length"` // default: 40
-}
-
-// Board represents a kanban board
-type Board struct {
-	ID        string               `json:"id"`
-	Name      string               `json:"name"`
-	RepoPath  string               `json:"repo_path"`
-	CreatedAt time.Time            `json:"created_at"`
-	UpdatedAt time.Time            `json:"updated_at"`
-	Columns   []Column             `json:"columns"`
-	Tickets   map[TicketID]*Ticket `json:"tickets"`
-	Settings  BoardSettings        `json:"settings"`
-}
-
-// NewBoard creates a new board with default columns
-func NewBoard(name, repoPath string, settings BoardSettings) *Board {
-	now := time.Now()
-
-	// Default worktree base if not set
-	if settings.WorktreeBase == "" {
-		settings.WorktreeBase = repoPath + "-worktrees"
-	}
-
-	return &Board{
-		ID:        uuid.New().String(),
-		Name:      name,
-		RepoPath:  repoPath,
-		CreatedAt: now,
-		UpdatedAt: now,
-		Columns: []Column{
-			{ID: "backlog", Name: "Backlog", Status: StatusBacklog, Color: "#89b4fa", Limit: 0},
-			{ID: "in-progress", Name: "In Progress", Status: StatusInProgress, Color: "#f9e2af", Limit: 3},
-			{ID: "done", Name: "Done", Status: StatusDone, Color: "#a6e3a1", Limit: 0},
-		},
-		Tickets:  make(map[TicketID]*Ticket),
-		Settings: settings,
+func DefaultColumns() []Column {
+	return []Column{
+		{ID: "backlog", Name: "Backlog", Status: StatusBacklog, Color: "#89b4fa", Limit: 0},
+		{ID: "in-progress", Name: "In Progress", Status: StatusInProgress, Color: "#f9e2af", Limit: 3},
+		{ID: "done", Name: "Done", Status: StatusDone, Color: "#a6e3a1", Limit: 0},
 	}
 }
 
-// GetTicketsByStatus returns all tickets with the given status
-func (b *Board) GetTicketsByStatus(status TicketStatus) []*Ticket {
-	var tickets []*Ticket
-	for _, t := range b.Tickets {
-		if t.Status == status {
-			tickets = append(tickets, t)
-		}
-	}
-	return tickets
-}
-
-// AddTicket adds a ticket to the board
-func (b *Board) AddTicket(t *Ticket) {
-	b.Tickets[t.ID] = t
-	b.UpdatedAt = time.Now()
-}
-
-// MoveTicket changes a ticket's status
-func (b *Board) MoveTicket(id TicketID, newStatus TicketStatus) error {
-	t, ok := b.Tickets[id]
-	if !ok {
-		return ErrTicketNotFound
-	}
-
-	now := time.Now()
-	t.Status = newStatus
-	t.UpdatedAt = now
-
-	switch newStatus {
-	case StatusInProgress:
-		t.StartedAt = &now
-	case StatusDone:
-		t.CompletedAt = &now
-	}
-
-	b.UpdatedAt = now
-	return nil
-}
-
-// DeleteTicket removes a ticket from the board
-func (b *Board) DeleteTicket(id TicketID) error {
-	if _, ok := b.Tickets[id]; !ok {
-		return ErrTicketNotFound
-	}
-	delete(b.Tickets, id)
-	b.UpdatedAt = time.Now()
-	return nil
-}
-
-// Errors
 var (
 	ErrTicketNotFound = &BoardError{Message: "ticket not found"}
-	ErrBoardNotFound  = &BoardError{Message: "board not found"}
 )
 
 type BoardError struct {
@@ -237,44 +150,4 @@ type BoardError struct {
 
 func (e *BoardError) Error() string {
 	return e.Message
-}
-
-// Save writes the board to a JSON file
-func (b *Board) Save(dir string) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-
-	path := filepath.Join(dir, b.ID+".json")
-	data, err := json.MarshalIndent(b, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	// Atomic write
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
-}
-
-// LoadBoard reads a board from a JSON file
-func LoadBoard(path string) (*Board, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var b Board
-	if err := json.Unmarshal(data, &b); err != nil {
-		return nil, err
-	}
-
-	// Initialize map if nil
-	if b.Tickets == nil {
-		b.Tickets = make(map[TicketID]*Ticket)
-	}
-
-	return &b, nil
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -6,38 +6,40 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/techdufus/openkanban/internal/project"
 )
 
-// WorktreeManager handles git worktree operations
 type WorktreeManager struct {
 	repoPath string
 	baseDir  string
 }
 
-// NewWorktreeManager creates a new worktree manager
-func NewWorktreeManager(repoPath, baseDir string) *WorktreeManager {
+func NewWorktreeManager(p *project.Project) *WorktreeManager {
+	return &WorktreeManager{
+		repoPath: p.RepoPath,
+		baseDir:  p.GetWorktreeDir(),
+	}
+}
+
+func NewWorktreeManagerFromPaths(repoPath, baseDir string) *WorktreeManager {
 	return &WorktreeManager{
 		repoPath: repoPath,
 		baseDir:  baseDir,
 	}
 }
 
-// CreateWorktree creates a new git worktree with a new branch
 func (m *WorktreeManager) CreateWorktree(branchName, baseBranch string) (string, error) {
-	// Ensure base directory exists
 	if err := os.MkdirAll(m.baseDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create worktree base directory: %w", err)
 	}
 
-	// Worktree path based on branch name
 	worktreePath := filepath.Join(m.baseDir, sanitizeBranchName(branchName))
 
-	// Check if worktree already exists
 	if _, err := os.Stat(worktreePath); err == nil {
 		return worktreePath, nil
 	}
 
-	// Create new branch and worktree
 	cmd := exec.Command("git", "worktree", "add", "-b", branchName, worktreePath, baseBranch)
 	cmd.Dir = m.repoPath
 
@@ -48,20 +50,16 @@ func (m *WorktreeManager) CreateWorktree(branchName, baseBranch string) (string,
 	return worktreePath, nil
 }
 
-// RemoveWorktree removes a git worktree
 func (m *WorktreeManager) RemoveWorktree(worktreePath string) error {
-	// First, remove from git
 	cmd := exec.Command("git", "worktree", "remove", worktreePath, "--force")
 	cmd.Dir = m.repoPath
 
 	if output, err := cmd.CombinedOutput(); err != nil {
-		// If worktree not found, just clean up the directory
 		if !strings.Contains(string(output), "not a working tree") {
 			return fmt.Errorf("failed to remove worktree: %s: %w", string(output), err)
 		}
 	}
 
-	// Clean up directory if it still exists
 	if _, err := os.Stat(worktreePath); err == nil {
 		if err := os.RemoveAll(worktreePath); err != nil {
 			return fmt.Errorf("failed to remove worktree directory: %w", err)
@@ -71,7 +69,6 @@ func (m *WorktreeManager) RemoveWorktree(worktreePath string) error {
 	return nil
 }
 
-// ListWorktrees returns all worktrees for the repository
 func (m *WorktreeManager) ListWorktrees() ([]Worktree, error) {
 	cmd := exec.Command("git", "worktree", "list", "--porcelain")
 	cmd.Dir = m.repoPath
@@ -84,28 +81,26 @@ func (m *WorktreeManager) ListWorktrees() ([]Worktree, error) {
 	return parseWorktreeList(string(output)), nil
 }
 
-// Worktree represents a git worktree
 type Worktree struct {
 	Path   string
 	HEAD   string
 	Branch string
 }
 
-// parseWorktreeList parses git worktree list --porcelain output
 func parseWorktreeList(output string) []Worktree {
 	var worktrees []Worktree
 	var current Worktree
 
 	for _, line := range strings.Split(output, "\n") {
-		if strings.HasPrefix(line, "worktree ") {
+		if after, found := strings.CutPrefix(line, "worktree "); found {
 			if current.Path != "" {
 				worktrees = append(worktrees, current)
 			}
-			current = Worktree{Path: strings.TrimPrefix(line, "worktree ")}
-		} else if strings.HasPrefix(line, "HEAD ") {
-			current.HEAD = strings.TrimPrefix(line, "HEAD ")
-		} else if strings.HasPrefix(line, "branch ") {
-			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+			current = Worktree{Path: after}
+		} else if after, found := strings.CutPrefix(line, "HEAD "); found {
+			current.HEAD = after
+		} else if after, found := strings.CutPrefix(line, "branch refs/heads/"); found {
+			current.Branch = after
 		}
 	}
 
@@ -116,9 +111,7 @@ func parseWorktreeList(output string) []Worktree {
 	return worktrees
 }
 
-// GetDefaultBranch returns the default branch of the repository
 func (m *WorktreeManager) GetDefaultBranch() (string, error) {
-	// Try to get from remote
 	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
 	cmd.Dir = m.repoPath
 
@@ -129,7 +122,6 @@ func (m *WorktreeManager) GetDefaultBranch() (string, error) {
 		return branch, nil
 	}
 
-	// Fall back to common defaults
 	for _, branch := range []string{"main", "master"} {
 		cmd := exec.Command("git", "rev-parse", "--verify", branch)
 		cmd.Dir = m.repoPath
@@ -141,7 +133,6 @@ func (m *WorktreeManager) GetDefaultBranch() (string, error) {
 	return "main", nil
 }
 
-// DeleteBranch deletes a git branch
 func (m *WorktreeManager) DeleteBranch(branchName string) error {
 	cmd := exec.Command("git", "branch", "-D", branchName)
 	cmd.Dir = m.repoPath
@@ -153,7 +144,6 @@ func (m *WorktreeManager) DeleteBranch(branchName string) error {
 	return nil
 }
 
-// HasUncommittedChanges checks if the worktree has uncommitted changes
 func (m *WorktreeManager) HasUncommittedChanges(worktreePath string) (bool, error) {
 	cmd := exec.Command("git", "status", "--porcelain")
 	cmd.Dir = worktreePath
@@ -166,16 +156,11 @@ func (m *WorktreeManager) HasUncommittedChanges(worktreePath string) (bool, erro
 	return len(strings.TrimSpace(string(output))) > 0, nil
 }
 
-// sanitizeBranchName converts a branch name to a safe directory name
 func sanitizeBranchName(name string) string {
-	// Remove common prefixes
 	name = strings.TrimPrefix(name, "refs/heads/")
 	name = strings.TrimPrefix(name, "agent/")
 	name = strings.TrimPrefix(name, "feature/")
-
-	// Replace slashes with dashes
 	name = strings.ReplaceAll(name, "/", "-")
-
 	return name
 }
 
@@ -196,14 +181,10 @@ func ResolveMainRepo(path string) string {
 	}
 
 	line := strings.TrimSpace(string(content))
-	if !strings.HasPrefix(line, "gitdir: ") {
-		return path
-	}
-
-	gitdir := strings.TrimPrefix(line, "gitdir: ")
-
-	if idx := strings.Index(gitdir, "/.git/worktrees/"); idx != -1 {
-		return gitdir[:idx]
+	if after, found := strings.CutPrefix(line, "gitdir: "); found {
+		if idx, _, hasWorktrees := strings.Cut(after, "/.git/worktrees/"); hasWorktrees {
+			return idx
+		}
 	}
 
 	return path

--- a/internal/project/filter.go
+++ b/internal/project/filter.go
@@ -1,0 +1,173 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/techdufus/openkanban/internal/board"
+	"github.com/techdufus/openkanban/internal/config"
+)
+
+type SavedFilter struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	ProjectIDs []string `json:"project_ids,omitempty"`
+	Statuses   []string `json:"statuses,omitempty"`
+	Labels     []string `json:"labels,omitempty"`
+	IsDefault  bool     `json:"is_default"`
+}
+
+func NewFilter(name string) *SavedFilter {
+	return &SavedFilter{
+		ID:   uuid.New().String(),
+		Name: name,
+	}
+}
+
+func (f *SavedFilter) Matches(ticket *board.Ticket) bool {
+	if len(f.ProjectIDs) > 0 {
+		found := false
+		for _, pid := range f.ProjectIDs {
+			if pid == ticket.ProjectID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	if len(f.Statuses) > 0 {
+		found := false
+		for _, s := range f.Statuses {
+			if s == string(ticket.Status) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	if len(f.Labels) > 0 {
+		found := false
+		for _, filterLabel := range f.Labels {
+			for _, ticketLabel := range ticket.Labels {
+				if filterLabel == ticketLabel {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+type FilterRegistry struct {
+	Filters map[string]*SavedFilter `json:"filters"`
+}
+
+func newFilterRegistry() *FilterRegistry {
+	return &FilterRegistry{
+		Filters: make(map[string]*SavedFilter),
+	}
+}
+
+func filterRegistryPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "filters.json"), nil
+}
+
+func LoadFilterRegistry() (*FilterRegistry, error) {
+	path, err := filterRegistryPath()
+	if err != nil {
+		return newFilterRegistry(), nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newFilterRegistry(), nil
+		}
+		return nil, err
+	}
+
+	var reg FilterRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, err
+	}
+
+	if reg.Filters == nil {
+		reg.Filters = make(map[string]*SavedFilter)
+	}
+
+	return &reg, nil
+}
+
+func (r *FilterRegistry) Save() error {
+	path, err := filterRegistryPath()
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (r *FilterRegistry) Add(f *SavedFilter) error {
+	r.Filters[f.ID] = f
+	return r.Save()
+}
+
+func (r *FilterRegistry) Get(id string) *SavedFilter {
+	return r.Filters[id]
+}
+
+func (r *FilterRegistry) GetDefault() *SavedFilter {
+	for _, f := range r.Filters {
+		if f.IsDefault {
+			return f
+		}
+	}
+	return nil
+}
+
+func (r *FilterRegistry) Delete(id string) error {
+	delete(r.Filters, id)
+	return r.Save()
+}
+
+func (r *FilterRegistry) List() []*SavedFilter {
+	result := make([]*SavedFilter, 0, len(r.Filters))
+	for _, f := range r.Filters {
+		result = append(result, f)
+	}
+	return result
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,95 @@
+package project
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Project represents a git repository registered with OpenKanban.
+// Each git repo is exactly one Project - this is the fundamental unit of organization.
+type Project struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	RepoPath    string    `json:"repo_path"`    // Absolute path to git repo root
+	WorktreeDir string    `json:"worktree_dir"` // Where worktrees go (default: {repo}-worktrees)
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+
+	// Project-specific settings (overrides global defaults)
+	Settings ProjectSettings `json:"settings"`
+}
+
+// ProjectSettings contains project-specific configuration.
+// These override global defaults from config.Config.
+type ProjectSettings struct {
+	DefaultAgent     string `json:"default_agent,omitempty"`
+	AutoSpawnAgent   bool   `json:"auto_spawn_agent"`
+	AutoCreateBranch bool   `json:"auto_create_branch"`
+	BranchPrefix     string `json:"branch_prefix,omitempty"`
+	BranchNaming     string `json:"branch_naming,omitempty"`   // "template" | "ai" | "prompt"
+	BranchTemplate   string `json:"branch_template,omitempty"` // e.g., "{prefix}{slug}"
+	SlugMaxLength    int    `json:"slug_max_length,omitempty"` // default: 40
+}
+
+// NewProject creates a new project for a repository
+func NewProject(name, repoPath string) *Project {
+	now := time.Now()
+
+	// Default worktree dir is sibling to repo: /path/to/repo -> /path/to/repo-worktrees
+	worktreeDir := repoPath + "-worktrees"
+
+	return &Project{
+		ID:          uuid.New().String(),
+		Name:        name,
+		RepoPath:    repoPath,
+		WorktreeDir: worktreeDir,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Settings: ProjectSettings{
+			AutoSpawnAgent:   true,
+			AutoCreateBranch: true,
+			BranchPrefix:     "task/",
+			BranchNaming:     "template",
+			BranchTemplate:   "{prefix}{slug}",
+			SlugMaxLength:    40,
+		},
+	}
+}
+
+// GetWorktreeDir returns the worktree directory, using default if not set
+func (p *Project) GetWorktreeDir() string {
+	if p.WorktreeDir != "" {
+		return p.WorktreeDir
+	}
+	return p.RepoPath + "-worktrees"
+}
+
+// GetBranchPrefix returns the branch prefix, using default if not set
+func (p *Project) GetBranchPrefix() string {
+	if p.Settings.BranchPrefix != "" {
+		return p.Settings.BranchPrefix
+	}
+	return "task/"
+}
+
+// GetBranchTemplate returns the branch template, using default if not set
+func (p *Project) GetBranchTemplate() string {
+	if p.Settings.BranchTemplate != "" {
+		return p.Settings.BranchTemplate
+	}
+	return "{prefix}{slug}"
+}
+
+// GetSlugMaxLength returns the slug max length, using default if not set
+func (p *Project) GetSlugMaxLength() int {
+	if p.Settings.SlugMaxLength > 0 {
+		return p.Settings.SlugMaxLength
+	}
+	return 40
+}
+
+// Touch updates the UpdatedAt timestamp
+func (p *Project) Touch() {
+	p.UpdatedAt = time.Now()
+}

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -1,0 +1,134 @@
+package project
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/techdufus/openkanban/internal/config"
+)
+
+var (
+	ErrProjectNotFound = errors.New("project not found")
+	ErrDuplicatePath   = errors.New("project with this repository path already exists")
+)
+
+type ProjectRegistry struct {
+	Projects map[string]*Project `json:"projects"`
+}
+
+func newRegistry() *ProjectRegistry {
+	return &ProjectRegistry{
+		Projects: make(map[string]*Project),
+	}
+}
+
+func registryPath() (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "projects.json"), nil
+}
+
+func LoadRegistry() (*ProjectRegistry, error) {
+	path, err := registryPath()
+	if err != nil {
+		return newRegistry(), nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newRegistry(), nil
+		}
+		return nil, err
+	}
+
+	var reg ProjectRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, err
+	}
+
+	if reg.Projects == nil {
+		reg.Projects = make(map[string]*Project)
+	}
+
+	return &reg, nil
+}
+
+func (r *ProjectRegistry) Save() error {
+	path, err := registryPath()
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (r *ProjectRegistry) Add(p *Project) error {
+	for _, existing := range r.Projects {
+		if existing.RepoPath == p.RepoPath {
+			return ErrDuplicatePath
+		}
+	}
+	r.Projects[p.ID] = p
+	return r.Save()
+}
+
+func (r *ProjectRegistry) Get(id string) (*Project, error) {
+	p, ok := r.Projects[id]
+	if !ok {
+		return nil, ErrProjectNotFound
+	}
+	return p, nil
+}
+
+func (r *ProjectRegistry) FindByPath(repoPath string) (*Project, error) {
+	for _, p := range r.Projects {
+		if p.RepoPath == repoPath {
+			return p, nil
+		}
+	}
+	return nil, ErrProjectNotFound
+}
+
+func (r *ProjectRegistry) Update(p *Project) error {
+	if _, ok := r.Projects[p.ID]; !ok {
+		return ErrProjectNotFound
+	}
+	p.Touch()
+	r.Projects[p.ID] = p
+	return r.Save()
+}
+
+func (r *ProjectRegistry) Delete(id string) error {
+	if _, ok := r.Projects[id]; !ok {
+		return ErrProjectNotFound
+	}
+	delete(r.Projects, id)
+	return r.Save()
+}
+
+func (r *ProjectRegistry) List() []*Project {
+	result := make([]*Project, 0, len(r.Projects))
+	for _, p := range r.Projects {
+		result = append(result, p)
+	}
+	return result
+}

--- a/internal/project/tickets.go
+++ b/internal/project/tickets.go
@@ -1,0 +1,289 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/techdufus/openkanban/internal/board"
+)
+
+const ticketsDir = ".openkanban"
+const ticketsFile = "tickets.json"
+
+type TicketStore struct {
+	ProjectID string                           `json:"project_id"`
+	Tickets   map[board.TicketID]*board.Ticket `json:"tickets"`
+	UpdatedAt time.Time                        `json:"updated_at"`
+
+	repoPath string
+}
+
+func NewTicketStore(projectID, repoPath string) *TicketStore {
+	return &TicketStore{
+		ProjectID: projectID,
+		Tickets:   make(map[board.TicketID]*board.Ticket),
+		UpdatedAt: time.Now(),
+		repoPath:  repoPath,
+	}
+}
+
+func LoadTicketStore(project *Project) (*TicketStore, error) {
+	store := NewTicketStore(project.ID, project.RepoPath)
+
+	path := store.filePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return store, nil
+		}
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, store); err != nil {
+		return nil, err
+	}
+
+	if store.Tickets == nil {
+		store.Tickets = make(map[board.TicketID]*board.Ticket)
+	}
+	store.repoPath = project.RepoPath
+
+	return store, nil
+}
+
+func (s *TicketStore) filePath() string {
+	return filepath.Join(s.repoPath, ticketsDir, ticketsFile)
+}
+
+func (s *TicketStore) Save() error {
+	dir := filepath.Join(s.repoPath, ticketsDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	s.UpdatedAt = time.Now()
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	path := s.filePath()
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func (s *TicketStore) Add(ticket *board.Ticket) {
+	ticket.ProjectID = s.ProjectID
+	s.Tickets[ticket.ID] = ticket
+}
+
+func (s *TicketStore) Get(id board.TicketID) (*board.Ticket, error) {
+	t, ok := s.Tickets[id]
+	if !ok {
+		return nil, board.ErrTicketNotFound
+	}
+	return t, nil
+}
+
+func (s *TicketStore) Delete(id board.TicketID) error {
+	if _, ok := s.Tickets[id]; !ok {
+		return board.ErrTicketNotFound
+	}
+	delete(s.Tickets, id)
+	return nil
+}
+
+func (s *TicketStore) Move(id board.TicketID, newStatus board.TicketStatus) error {
+	t, ok := s.Tickets[id]
+	if !ok {
+		return board.ErrTicketNotFound
+	}
+	t.SetStatus(newStatus)
+	return nil
+}
+
+func (s *TicketStore) GetByStatus(status board.TicketStatus) []*board.Ticket {
+	var result []*board.Ticket
+	for _, t := range s.Tickets {
+		if t.Status == status {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (s *TicketStore) All() []*board.Ticket {
+	result := make([]*board.Ticket, 0, len(s.Tickets))
+	for _, t := range s.Tickets {
+		result = append(result, t)
+	}
+	return result
+}
+
+func (s *TicketStore) Count() int {
+	return len(s.Tickets)
+}
+
+func (s *TicketStore) CountByStatus(status board.TicketStatus) int {
+	count := 0
+	for _, t := range s.Tickets {
+		if t.Status == status {
+			count++
+		}
+	}
+	return count
+}
+
+// GlobalTicketStore aggregates tickets from all projects
+type GlobalTicketStore struct {
+	projects     map[string]*Project
+	ticketStores map[string]*TicketStore
+	allTickets   map[board.TicketID]*board.Ticket
+}
+
+func NewGlobalTicketStore() *GlobalTicketStore {
+	return &GlobalTicketStore{
+		projects:     make(map[string]*Project),
+		ticketStores: make(map[string]*TicketStore),
+		allTickets:   make(map[board.TicketID]*board.Ticket),
+	}
+}
+
+func LoadGlobalTicketStore(registry *ProjectRegistry) (*GlobalTicketStore, error) {
+	g := NewGlobalTicketStore()
+
+	for _, p := range registry.Projects {
+		store, err := LoadTicketStore(p)
+		if err != nil {
+			continue
+		}
+
+		g.projects[p.ID] = p
+		g.ticketStores[p.ID] = store
+
+		for id, ticket := range store.Tickets {
+			g.allTickets[id] = ticket
+		}
+	}
+
+	return g, nil
+}
+
+func (g *GlobalTicketStore) GetProject(id string) *Project {
+	return g.projects[id]
+}
+
+func (g *GlobalTicketStore) GetProjectForTicket(ticket *board.Ticket) *Project {
+	return g.projects[ticket.ProjectID]
+}
+
+func (g *GlobalTicketStore) GetStoreForTicket(ticket *board.Ticket) *TicketStore {
+	return g.ticketStores[ticket.ProjectID]
+}
+
+func (g *GlobalTicketStore) Get(id board.TicketID) (*board.Ticket, error) {
+	t, ok := g.allTickets[id]
+	if !ok {
+		return nil, board.ErrTicketNotFound
+	}
+	return t, nil
+}
+
+func (g *GlobalTicketStore) Add(ticket *board.Ticket) error {
+	store := g.ticketStores[ticket.ProjectID]
+	if store == nil {
+		return board.ErrTicketNotFound
+	}
+	store.Add(ticket)
+	g.allTickets[ticket.ID] = ticket
+	return nil
+}
+
+func (g *GlobalTicketStore) Delete(id board.TicketID) error {
+	ticket, ok := g.allTickets[id]
+	if !ok {
+		return board.ErrTicketNotFound
+	}
+
+	store := g.ticketStores[ticket.ProjectID]
+	if store != nil {
+		store.Delete(id)
+	}
+	delete(g.allTickets, id)
+	return nil
+}
+
+func (g *GlobalTicketStore) Move(id board.TicketID, newStatus board.TicketStatus) error {
+	ticket, ok := g.allTickets[id]
+	if !ok {
+		return board.ErrTicketNotFound
+	}
+
+	store := g.ticketStores[ticket.ProjectID]
+	if store != nil {
+		store.Move(id, newStatus)
+	}
+	return nil
+}
+
+func (g *GlobalTicketStore) Save(ticket *board.Ticket) error {
+	store := g.ticketStores[ticket.ProjectID]
+	if store == nil {
+		return board.ErrTicketNotFound
+	}
+	return store.Save()
+}
+
+func (g *GlobalTicketStore) SaveAll() error {
+	for _, store := range g.ticketStores {
+		if err := store.Save(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *GlobalTicketStore) GetByStatus(status board.TicketStatus) []*board.Ticket {
+	var result []*board.Ticket
+	for _, t := range g.allTickets {
+		if t.Status == status {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (g *GlobalTicketStore) All() []*board.Ticket {
+	result := make([]*board.Ticket, 0, len(g.allTickets))
+	for _, t := range g.allTickets {
+		result = append(result, t)
+	}
+	return result
+}
+
+func (g *GlobalTicketStore) Count() int {
+	return len(g.allTickets)
+}
+
+func (g *GlobalTicketStore) Projects() []*Project {
+	result := make([]*Project, 0, len(g.projects))
+	for _, p := range g.projects {
+		result = append(result, p)
+	}
+	return result
+}
+
+func (g *GlobalTicketStore) HasProjects() bool {
+	return len(g.projects) > 0
+}
+
+func (g *GlobalTicketStore) AddProject(p *Project) {
+	g.projects[p.ID] = p
+	g.ticketStores[p.ID] = NewTicketStore(p.ID, p.RepoPath)
+}


### PR DESCRIPTION
## Summary

Refactors OpenKanban from a board-per-directory model to a project-centric global view. Running `openkanban` now shows all tickets from all registered projects in a unified view.

Key changes:
- Project registry at `~/.config/openkanban/projects.json`
- Per-project ticket storage in `{repo}/.openkanban/tickets.json`
- GlobalTicketStore aggregates tickets across all projects
- Press `p` to cycle project filter

Closes #47