### PR TITLE
Add config validation with helpful error messages

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/techdufus/openkanban/internal/config"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Configuration management",
+	Long:  "Commands for managing OpenKanban configuration files.",
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate configuration file",
+	Long:  "Check the configuration file for errors and display helpful messages.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := cfgFile
+		if path == "" {
+			var err error
+			path, err = config.ConfigPath()
+			if err != nil {
+				return fmt.Errorf("failed to determine config path: %w", err)
+			}
+		}
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			fmt.Printf("No config file found at %s\n", path)
+			fmt.Println("Using default configuration.")
+			fmt.Println("\nRun 'openkanban config generate' to create a config file.")
+			return nil
+		}
+
+		cfg, result, err := config.LoadWithValidation(path)
+		if err != nil && result == nil {
+			return fmt.Errorf("failed to read config: %w", err)
+		}
+
+		if result != nil && result.HasErrors() {
+			fmt.Fprintf(os.Stderr, "Config errors in %s:\n\n", path)
+			fmt.Fprint(os.Stderr, result.FormatErrors())
+			os.Exit(1)
+		}
+
+		if result != nil && result.HasWarnings() {
+			fmt.Printf("Config valid with %d warning(s) in %s:\n\n", len(result.Warnings), path)
+			fmt.Print(result.FormatWarnings())
+			return nil
+		}
+
+		_ = cfg
+		fmt.Printf("Configuration is valid: %s\n", path)
+		return nil
+	},
+}
+
+var forceGenerate bool
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate default configuration file",
+	Long:  "Create a new configuration file with default values.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := cfgFile
+		if path == "" {
+			var err error
+			path, err = config.ConfigPath()
+			if err != nil {
+				return fmt.Errorf("failed to determine config path: %w", err)
+			}
+		}
+
+		if _, err := os.Stat(path); err == nil {
+			if !forceGenerate {
+				return fmt.Errorf("config file already exists at %s (use --force to overwrite)", path)
+			}
+		}
+
+		cfg := config.DefaultConfig()
+		if err := cfg.Save(path); err != nil {
+			return fmt.Errorf("failed to write config: %w", err)
+		}
+
+		fmt.Printf("Generated config at %s\n", path)
+		return nil
+	},
+}
+
+var showPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Show configuration file path",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := cfgFile
+		if path == "" {
+			var err error
+			path, err = config.ConfigPath()
+			if err != nil {
+				return fmt.Errorf("failed to determine config path: %w", err)
+			}
+		}
+
+		fmt.Println(path)
+
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "(file does not exist)")
+		}
+		return nil
+	},
+}
+
+func init() {
+	configCmd.AddCommand(validateCmd)
+	configCmd.AddCommand(generateCmd)
+	configCmd.AddCommand(showPathCmd)
+
+	generateCmd.Flags().BoolVarP(&forceGenerate, "force", "f", false, "overwrite existing config file")
+
+	rootCmd.AddCommand(configCmd)
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,214 @@
+package config
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+// ValidationError represents a single config validation issue
+type ValidationError struct {
+	Section string // "defaults", "agents.claude", "ui", etc.
+	Field   string // "command", "branch_naming", etc.
+	Message string // Human-readable error
+	Value   any    // The invalid value (for display)
+}
+
+// ValidationResult holds all validation errors and warnings
+type ValidationResult struct {
+	Errors   []ValidationError
+	Warnings []ValidationError
+}
+
+// HasErrors returns true if there are any validation errors
+func (r *ValidationResult) HasErrors() bool {
+	return len(r.Errors) > 0
+}
+
+// HasWarnings returns true if there are any validation warnings
+func (r *ValidationResult) HasWarnings() bool {
+	return len(r.Warnings) > 0
+}
+
+// AddError adds a validation error
+func (r *ValidationResult) AddError(section, field, message string, value any) {
+	r.Errors = append(r.Errors, ValidationError{
+		Section: section,
+		Field:   field,
+		Message: message,
+		Value:   value,
+	})
+}
+
+// AddWarning adds a validation warning
+func (r *ValidationResult) AddWarning(section, field, message string, value any) {
+	r.Warnings = append(r.Warnings, ValidationError{
+		Section: section,
+		Field:   field,
+		Message: message,
+		Value:   value,
+	})
+}
+
+// FormatErrors returns a formatted string of all errors for CLI output
+func (r *ValidationResult) FormatErrors() string {
+	var sb strings.Builder
+	for _, e := range r.Errors {
+		if e.Field != "" {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", e.Section, e.Field))
+		} else {
+			sb.WriteString(fmt.Sprintf("  [%s]\n", e.Section))
+		}
+		sb.WriteString(fmt.Sprintf("    %s\n", e.Message))
+		if e.Value != nil {
+			sb.WriteString(fmt.Sprintf("    got: %v\n", e.Value))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// FormatWarnings returns a formatted string of all warnings for CLI output
+func (r *ValidationResult) FormatWarnings() string {
+	var sb strings.Builder
+	for _, w := range r.Warnings {
+		if w.Field != "" {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", w.Section, w.Field))
+		} else {
+			sb.WriteString(fmt.Sprintf("  [%s]\n", w.Section))
+		}
+		sb.WriteString(fmt.Sprintf("    %s\n", w.Message))
+		if w.Value != nil {
+			sb.WriteString(fmt.Sprintf("    got: %v\n", w.Value))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// Validate performs full config validation and returns all errors and warnings
+func (c *Config) Validate() *ValidationResult {
+	result := &ValidationResult{}
+	c.validateDefaults(result)
+	c.validateAgents(result)
+	c.validateUI(result)
+	c.validateOpencode(result)
+	return result
+}
+
+// validateDefaults validates the defaults section
+func (c *Config) validateDefaults(r *ValidationResult) {
+	// BranchNaming must be a valid enum value
+	validNaming := map[string]bool{"template": true, "ai": true, "prompt": true, "": true}
+	if !validNaming[c.Defaults.BranchNaming] {
+		r.AddError("defaults", "branch_naming",
+			fmt.Sprintf("must be one of: template, ai, prompt (got %q)", c.Defaults.BranchNaming),
+			c.Defaults.BranchNaming)
+	}
+
+	// SlugMaxLength must be positive if set
+	if c.Defaults.SlugMaxLength < 0 {
+		r.AddError("defaults", "slug_max_length",
+			"must be a positive number",
+			c.Defaults.SlugMaxLength)
+	}
+
+	// DefaultAgent must reference a defined agent (if set)
+	if c.Defaults.DefaultAgent != "" {
+		if _, exists := c.Agents[c.Defaults.DefaultAgent]; !exists {
+			r.AddError("defaults", "default_agent",
+				fmt.Sprintf("references undefined agent %q", c.Defaults.DefaultAgent),
+				c.Defaults.DefaultAgent)
+		}
+	}
+
+	// BranchTemplate should contain placeholders (warning only)
+	if c.Defaults.BranchTemplate != "" {
+		if !strings.Contains(c.Defaults.BranchTemplate, "{slug}") &&
+			!strings.Contains(c.Defaults.BranchTemplate, "{prefix}") {
+			r.AddWarning("defaults", "branch_template",
+				"should contain {slug} or {prefix} placeholder",
+				c.Defaults.BranchTemplate)
+		}
+	}
+
+	// Validate InitPrompt template syntax
+	if c.Defaults.InitPrompt != "" {
+		if err := validateTemplate(c.Defaults.InitPrompt); err != nil {
+			r.AddError("defaults", "init_prompt",
+				fmt.Sprintf("invalid Go template syntax: %v", err),
+				nil)
+		}
+	}
+}
+
+// validateAgents validates the agents section
+func (c *Config) validateAgents(r *ValidationResult) {
+	for name, agent := range c.Agents {
+		section := fmt.Sprintf("agents.%s", name)
+
+		// Command is required
+		if agent.Command == "" {
+			r.AddError(section, "command", "is required but missing", nil)
+		} else {
+			// Check if command exists in PATH (warning only)
+			if _, err := exec.LookPath(agent.Command); err != nil {
+				r.AddWarning(section, "command",
+					fmt.Sprintf("executable %q not found in PATH", agent.Command),
+					agent.Command)
+			}
+		}
+
+		// Validate InitPrompt template syntax
+		if agent.InitPrompt != "" {
+			if err := validateTemplate(agent.InitPrompt); err != nil {
+				r.AddError(section, "init_prompt",
+					fmt.Sprintf("invalid Go template syntax: %v", err),
+					nil)
+			}
+		}
+	}
+}
+
+// validateUI validates the UI section
+func (c *Config) validateUI(r *ValidationResult) {
+	if c.UI.ColumnWidth <= 0 {
+		r.AddError("ui", "column_width",
+			"must be a positive number",
+			c.UI.ColumnWidth)
+	}
+
+	if c.UI.TicketHeight <= 0 {
+		r.AddError("ui", "ticket_height",
+			"must be a positive number",
+			c.UI.TicketHeight)
+	}
+
+	if c.UI.RefreshInterval <= 0 {
+		r.AddError("ui", "refresh_interval",
+			"must be a positive number",
+			c.UI.RefreshInterval)
+	}
+}
+
+// validateOpencode validates the opencode server settings
+func (c *Config) validateOpencode(r *ValidationResult) {
+	if c.Opencode.ServerPort < 0 || c.Opencode.ServerPort > 65535 {
+		r.AddError("opencode", "server_port",
+			"must be between 1 and 65535",
+			c.Opencode.ServerPort)
+	}
+
+	if c.Opencode.PollInterval < 0 {
+		r.AddError("opencode", "poll_interval",
+			"must be a positive number",
+			c.Opencode.PollInterval)
+	}
+}
+
+// validateTemplate checks if a string is a valid Go template
+func validateTemplate(tmpl string) error {
+	_, err := template.New("check").Parse(tmpl)
+	return err
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,456 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_ValidDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	result := cfg.Validate()
+
+	if result.HasErrors() {
+		t.Errorf("default config should be valid, got errors:\n%s", result.FormatErrors())
+	}
+}
+
+func TestValidate_InvalidBranchNaming(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.BranchNaming = "invalid"
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for invalid branch_naming")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "defaults" && e.Field == "branch_naming" {
+			found = true
+			if !strings.Contains(e.Message, "template, ai, prompt") {
+				t.Errorf("error message should list valid values; got %q", e.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected error for defaults.branch_naming")
+	}
+}
+
+func TestValidate_NegativeSlugMaxLength(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.SlugMaxLength = -1
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for negative slug_max_length")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "defaults" && e.Field == "slug_max_length" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for defaults.slug_max_length")
+	}
+}
+
+func TestValidate_NonexistentDefaultAgent(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.DefaultAgent = "nonexistent-agent"
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for nonexistent default_agent")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "defaults" && e.Field == "default_agent" {
+			found = true
+			if !strings.Contains(e.Message, "nonexistent-agent") {
+				t.Errorf("error message should mention the agent name; got %q", e.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected error for defaults.default_agent")
+	}
+}
+
+func TestValidate_BranchTemplateMissingPlaceholders(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.BranchTemplate = "feature-branch"
+
+	result := cfg.Validate()
+
+	// This should be a warning, not an error
+	if result.HasErrors() {
+		t.Errorf("missing placeholders should be a warning, not error:\n%s", result.FormatErrors())
+	}
+
+	if !result.HasWarnings() {
+		t.Error("expected warning for branch_template without placeholders")
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Section == "defaults" && w.Field == "branch_template" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning for defaults.branch_template")
+	}
+}
+
+func TestValidate_MissingAgentCommand(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agents["custom"] = AgentConfig{
+		Command: "",
+		Args:    []string{},
+	}
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for missing agent command")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "agents.custom" && e.Field == "command" {
+			found = true
+			if !strings.Contains(e.Message, "required") {
+				t.Errorf("error message should mention 'required'; got %q", e.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected error for agents.custom.command")
+	}
+}
+
+func TestValidate_CommandNotInPath(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agents["custom"] = AgentConfig{
+		Command: "nonexistent-binary-12345",
+		Args:    []string{},
+	}
+
+	result := cfg.Validate()
+
+	// This should be a warning, not an error
+	hasCommandWarning := false
+	for _, w := range result.Warnings {
+		if w.Section == "agents.custom" && w.Field == "command" {
+			hasCommandWarning = true
+			if !strings.Contains(w.Message, "not found in PATH") {
+				t.Errorf("warning should mention PATH; got %q", w.Message)
+			}
+		}
+	}
+	if !hasCommandWarning {
+		t.Error("expected warning for command not in PATH")
+	}
+}
+
+func TestValidate_InvalidTemplatePrompt(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agents["custom"] = AgentConfig{
+		Command:    "echo",
+		InitPrompt: "{{.Invalid syntax",
+	}
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for invalid template syntax")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "agents.custom" && e.Field == "init_prompt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for agents.custom.init_prompt")
+	}
+}
+
+func TestValidate_InvalidDefaultsInitPrompt(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.InitPrompt = "{{.Broken"
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for invalid defaults.init_prompt")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "defaults" && e.Field == "init_prompt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for defaults.init_prompt")
+	}
+}
+
+func TestValidate_ZeroUIColumnWidth(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.UI.ColumnWidth = 0
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for zero column_width")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "ui" && e.Field == "column_width" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for ui.column_width")
+	}
+}
+
+func TestValidate_ZeroUITicketHeight(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.UI.TicketHeight = 0
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for zero ticket_height")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "ui" && e.Field == "ticket_height" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for ui.ticket_height")
+	}
+}
+
+func TestValidate_ZeroUIRefreshInterval(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.UI.RefreshInterval = 0
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for zero refresh_interval")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "ui" && e.Field == "refresh_interval" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for ui.refresh_interval")
+	}
+}
+
+func TestValidate_InvalidServerPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+	}{
+		{"negative port", -1},
+		{"port too high", 70000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Opencode.ServerPort = tt.port
+
+			result := cfg.Validate()
+
+			if !result.HasErrors() {
+				t.Error("expected validation error for invalid server_port")
+			}
+
+			found := false
+			for _, e := range result.Errors {
+				if e.Section == "opencode" && e.Field == "server_port" {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected error for opencode.server_port with value %d", tt.port)
+			}
+		})
+	}
+}
+
+func TestValidate_NegativePollInterval(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Opencode.PollInterval = -1
+
+	result := cfg.Validate()
+
+	if !result.HasErrors() {
+		t.Error("expected validation error for negative poll_interval")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Section == "opencode" && e.Field == "poll_interval" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected error for opencode.poll_interval")
+	}
+}
+
+func TestValidationResult_FormatErrors(t *testing.T) {
+	r := &ValidationResult{}
+	r.AddError("defaults", "branch_naming", "must be valid", "invalid")
+	r.AddError("agents.custom", "command", "is required", nil)
+
+	output := r.FormatErrors()
+
+	if !strings.Contains(output, "defaults") {
+		t.Error("formatted errors should contain section name")
+	}
+	if !strings.Contains(output, "branch_naming") {
+		t.Error("formatted errors should contain field name")
+	}
+	if !strings.Contains(output, "must be valid") {
+		t.Error("formatted errors should contain message")
+	}
+	if !strings.Contains(output, "invalid") {
+		t.Error("formatted errors should contain value")
+	}
+	if !strings.Contains(output, "agents.custom") {
+		t.Error("formatted errors should contain nested section")
+	}
+}
+
+func TestValidationResult_FormatWarnings(t *testing.T) {
+	r := &ValidationResult{}
+	r.AddWarning("agents.custom", "command", "not found in PATH", "custom-agent")
+
+	output := r.FormatWarnings()
+
+	if !strings.Contains(output, "agents.custom") {
+		t.Error("formatted warnings should contain section name")
+	}
+	if !strings.Contains(output, "command") {
+		t.Error("formatted warnings should contain field name")
+	}
+	if !strings.Contains(output, "not found in PATH") {
+		t.Error("formatted warnings should contain message")
+	}
+}
+
+func TestValidationResult_HasErrors(t *testing.T) {
+	r := &ValidationResult{}
+
+	if r.HasErrors() {
+		t.Error("empty result should not have errors")
+	}
+
+	r.AddError("test", "field", "message", nil)
+
+	if !r.HasErrors() {
+		t.Error("result with error should have errors")
+	}
+}
+
+func TestValidationResult_HasWarnings(t *testing.T) {
+	r := &ValidationResult{}
+
+	if r.HasWarnings() {
+		t.Error("empty result should not have warnings")
+	}
+
+	r.AddWarning("test", "field", "message", nil)
+
+	if !r.HasWarnings() {
+		t.Error("result with warning should have warnings")
+	}
+}
+
+func TestValidate_MultipleErrors(t *testing.T) {
+	cfg := &Config{
+		Defaults: BoardSettings{
+			DefaultAgent:   "nonexistent",
+			BranchNaming:   "invalid",
+			SlugMaxLength:  -1,
+			BranchTemplate: "no-placeholders",
+		},
+		Agents: map[string]AgentConfig{
+			"bad": {Command: ""},
+		},
+		UI: UIConfig{
+			ColumnWidth:     0,
+			TicketHeight:    0,
+			RefreshInterval: 0,
+		},
+		Opencode: OpencodeSettings{
+			ServerPort:   -1,
+			PollInterval: -1,
+		},
+	}
+
+	result := cfg.Validate()
+
+	// Should have multiple errors
+	if len(result.Errors) < 5 {
+		t.Errorf("expected at least 5 errors, got %d:\n%s", len(result.Errors), result.FormatErrors())
+	}
+
+	// Should have at least one warning (branch_template)
+	if len(result.Warnings) < 1 {
+		t.Error("expected at least 1 warning for branch_template")
+	}
+}
+
+func TestValidate_EmptyBranchNamingIsValid(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Defaults.BranchNaming = ""
+
+	result := cfg.Validate()
+
+	for _, e := range result.Errors {
+		if e.Field == "branch_naming" {
+			t.Error("empty branch_naming should be valid (uses default)")
+		}
+	}
+}
+
+func TestValidate_ValidTemplatePrompt(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agents["custom"] = AgentConfig{
+		Command:    "echo",
+		InitPrompt: "Working on: {{.Title}}\nDescription: {{.Description}}",
+	}
+
+	result := cfg.Validate()
+
+	for _, e := range result.Errors {
+		if e.Section == "agents.custom" && e.Field == "init_prompt" {
+			t.Errorf("valid template should not produce error: %s", e.Message)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds comprehensive config validation with user-friendly error messages. Users now get clear, actionable feedback when their config has issues instead of cryptic JSON unmarshal errors.

New CLI commands:
- `openkanban config validate` - check config for errors
- `openkanban config generate` - create default config file  
- `openkanban config path` - show config file location

Validation runs on startup and blocks with clear errors if config is invalid. Warnings (like missing PATH commands) print but don't block.

Closes #54