### PR TITLE
feat(ui): add animated spinner for waiting status

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -124,9 +124,9 @@ func (m *Model) renderHeader() string {
 
 		if waitingCount > 0 {
 			bgColor = colorMauve
-			statusText = fmt.Sprintf("◐ %d waiting", waitingCount)
+			statusText = fmt.Sprintf("%s %d waiting", m.waitingSpinner.View(), waitingCount)
 			if workingCount > 0 {
-				statusText = fmt.Sprintf("◐ %d waiting, %d working", waitingCount, workingCount)
+				statusText = fmt.Sprintf("%s %d waiting, %d working", m.waitingSpinner.View(), waitingCount, workingCount)
 			}
 		} else if workingCount > 0 {
 			bgColor = colorYellow
@@ -362,7 +362,7 @@ func (m *Model) renderTicket(ticket *board.Ticket, isSelected, isHovered bool, w
 	case board.AgentWaiting:
 		sessionBadge = lipgloss.NewStyle().
 			Foreground(colorMauve).
-			Render("◐")
+			Render(m.waitingSpinner.View())
 	case board.AgentIdle:
 		if hasPane {
 			sessionBadge = lipgloss.NewStyle().
@@ -431,7 +431,7 @@ func (m *Model) renderTicket(ticket *board.Ticket, isSelected, isHovered bool, w
 			statusText = "working"
 			statusColor = colorYellow
 		case board.AgentWaiting:
-			statusIcon = "◐"
+			statusIcon = m.waitingSpinner.View()
 			statusText = "waiting"
 			statusColor = colorMauve
 		case board.AgentCompleted:


### PR DESCRIPTION
## Summary

- Adds a second spinner (`waitingSpinner`) with moon phase rotation animation (◐ ◓ ◑ ◒) for agents in "waiting" status
- Uses slow 4 FPS tick rate for a subtle pulsing effect that's not distracting
- Applied in both ticket cards and header activity badge

The "working" status already had spinner animation; this extends that pattern to "waiting" status as requested in #56.

Closes #56