### PR TITLE
feat: add per-ticket worktree toggle

### DIFF
--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -73,6 +73,7 @@ type Ticket struct {
 	Description string       `json:"description,omitempty"`
 	Status      TicketStatus `json:"status"`
 
+	UseWorktree  bool   `json:"use_worktree"`
 	WorktreePath string `json:"worktree_path,omitempty"`
 	BranchName   string `json:"branch_name,omitempty"`
 	BaseBranch   string `json:"base_branch,omitempty"`
@@ -100,6 +101,7 @@ func NewTicket(title, projectID string) *Ticket {
 		Title:       title,
 		Status:      StatusBacklog,
 		AgentStatus: AgentNone,
+		UseWorktree: true,
 		Priority:    3,
 		CreatedAt:   now,
 		UpdatedAt:   now,

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -165,6 +165,43 @@ func (m *WorktreeManager) DeleteBranch(branchName string) error {
 	return nil
 }
 
+func (m *WorktreeManager) BranchExists(branchName string) bool {
+	cmd := exec.Command("git", "rev-parse", "--verify", branchName)
+	cmd.Dir = m.repoPath
+	return cmd.Run() == nil
+}
+
+func (m *WorktreeManager) CreateBranch(branchName, baseBranch string) error {
+	cmd := exec.Command("git", "branch", branchName, baseBranch)
+	cmd.Dir = m.repoPath
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to create branch: %s: %w", string(output), err)
+	}
+
+	return nil
+}
+
+func (m *WorktreeManager) CheckoutBranch(branchName string) error {
+	cmd := exec.Command("git", "checkout", branchName)
+	cmd.Dir = m.repoPath
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to checkout branch: %s: %w", string(output), err)
+	}
+
+	return nil
+}
+
+func (m *WorktreeManager) SetupBranch(branchName, baseBranch string) error {
+	if !m.BranchExists(branchName) {
+		if err := m.CreateBranch(branchName, baseBranch); err != nil {
+			return err
+		}
+	}
+	return m.CheckoutBranch(branchName)
+}
+
 func (m *WorktreeManager) HasUncommittedChanges(worktreePath string) (bool, error) {
 	cmd := exec.Command("git", "status", "--porcelain")
 	cmd.Dir = worktreePath

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -809,6 +809,7 @@ func (m *Model) renderTicketForm() string {
 	branchLabel := labelStyle
 	labelsLabel := labelStyle
 	priorityLabel := labelStyle
+	worktreeLabel := labelStyle
 	projectLabel := labelStyle
 
 	switch m.ticketFormField {
@@ -822,6 +823,8 @@ func (m *Model) renderTicketForm() string {
 		labelsLabel = activeLabelStyle
 	case formFieldPriority:
 		priorityLabel = activeLabelStyle
+	case formFieldWorktree:
+		worktreeLabel = activeLabelStyle
 	case formFieldProject:
 		projectLabel = activeLabelStyle
 	}
@@ -838,6 +841,7 @@ func (m *Model) renderTicketForm() string {
 	}
 
 	priorityField := m.renderPrioritySelector()
+	worktreeField := m.renderWorktreeSelector()
 	projectField := m.renderProjectSelector()
 
 	titleCharCount := fmt.Sprintf("%d/100", len(m.titleInput.Value()))
@@ -852,7 +856,7 @@ func (m *Model) renderTicketForm() string {
 	focusIndicator := lipgloss.NewStyle().Foreground(colorTeal).Render("▸ ")
 	noFocus := "  "
 
-	titleFocus, descFocus, branchFocus, labelsFocus, priorityFocus, projectFocus := noFocus, noFocus, noFocus, noFocus, noFocus, noFocus
+	titleFocus, descFocus, branchFocus, labelsFocus, priorityFocus, worktreeFocus, projectFocus := noFocus, noFocus, noFocus, noFocus, noFocus, noFocus, noFocus
 	switch m.ticketFormField {
 	case formFieldTitle:
 		titleFocus = focusIndicator
@@ -864,6 +868,8 @@ func (m *Model) renderTicketForm() string {
 		labelsFocus = focusIndicator
 	case formFieldPriority:
 		priorityFocus = focusIndicator
+	case formFieldWorktree:
+		worktreeFocus = focusIndicator
 	case formFieldProject:
 		projectFocus = focusIndicator
 	}
@@ -883,7 +889,10 @@ func (m *Model) renderTicketForm() string {
 		"  " + m.labelsInput.View() + "\n\n" +
 		priorityFocus + priorityLabel.Render("Priority") + "\n" +
 		"  " + descriptionStyle.Render("1 = highest, 5 = lowest") + "\n" +
-		"  " + priorityField + "\n"
+		"  " + priorityField + "\n\n" +
+		worktreeFocus + worktreeLabel.Render("Worktree") + "\n" +
+		"  " + descriptionStyle.Render("Use isolated worktree or work in main repo") + "\n" +
+		"  " + worktreeField + "\n"
 
 	if !isEdit {
 		content += "\n" + projectFocus + projectLabel.Render("Project") + "\n" +
@@ -932,6 +941,29 @@ func (m *Model) renderPrioritySelector() string {
 	}
 
 	return strings.Join(parts, "  ") + hint
+}
+
+func (m *Model) renderWorktreeSelector() string {
+	worktreeStyle := lipgloss.NewStyle().Foreground(colorGreen)
+	mainRepoStyle := lipgloss.NewStyle().Foreground(colorYellow)
+
+	var worktreeOption, mainOption string
+	if m.ticketUseWorktree {
+		worktreeStyle = worktreeStyle.Bold(true).Background(colorSurface).Padding(0, 1)
+		worktreeOption = worktreeStyle.Render("● Worktree")
+		mainOption = mainRepoStyle.Render("○ Main Repo")
+	} else {
+		mainRepoStyle = mainRepoStyle.Bold(true).Background(colorSurface).Padding(0, 1)
+		worktreeOption = worktreeStyle.Render("○ Worktree")
+		mainOption = mainRepoStyle.Render("● Main Repo")
+	}
+
+	hint := ""
+	if m.ticketFormField == formFieldWorktree {
+		hint = "  " + dimStyle.Render("Space to toggle")
+	}
+
+	return worktreeOption + "  " + mainOption + hint
 }
 
 func (m *Model) renderWithOverlay(overlay string) string {


### PR DESCRIPTION
## Summary

- Adds a UseWorktree toggle to ticket creation/edit form, letting users choose between worktree isolation or main repo mode per ticket
- Main repo mode creates and checks out the branch in place instead of creating a separate worktree
- Prevents multiple main-repo agents from running in the same project since they'd conflict over the same directory