### PR TITLE
feat: add auto-update notifications on startup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/techdufus/openkanban/cmd.version={{.Version}}
-      - -X github.com/techdufus/openkanban/cmd.commit={{.ShortCommit}}
-      - -X github.com/techdufus/openkanban/cmd.date={{.Date}}
+      - -X github.com/techdufus/openkanban/cmd.Version={{.Version}}
+      - -X github.com/techdufus/openkanban/cmd.Commit={{.ShortCommit}}
+      - -X github.com/techdufus/openkanban/cmd.Date={{.Date}}
 
 archives:
   - formats: [tar.gz]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ for safe parallel development.`,
 			fmt.Fprintf(os.Stderr, "Config warnings:\n%s\n", result.FormatWarnings())
 		}
 
-		return app.Run(cfg, projectPath)
+		return app.Run(cfg, projectPath, Version)
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,18 +9,18 @@ import (
 
 // Set via ldflags at build time
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
 )
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("openkanban %s\n", version)
-		fmt.Printf("  commit: %s\n", commit)
-		fmt.Printf("  built:  %s\n", date)
+		fmt.Printf("openkanban %s\n", Version)
+		fmt.Printf("  commit: %s\n", Commit)
+		fmt.Printf("  built:  %s\n", Date)
 		fmt.Printf("  go:     %s\n", runtime.Version())
 	},
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,9 +13,10 @@ import (
 	"github.com/techdufus/openkanban/internal/git"
 	"github.com/techdufus/openkanban/internal/project"
 	"github.com/techdufus/openkanban/internal/ui"
+	"github.com/techdufus/openkanban/internal/update"
 )
 
-func Run(cfg *config.Config, filterPath string) error {
+func Run(cfg *config.Config, filterPath, version string) error {
 	registry, err := project.LoadRegistry()
 	if err != nil {
 		return fmt.Errorf("failed to load project registry: %w", err)
@@ -47,7 +48,8 @@ func Run(cfg *config.Config, filterPath string) error {
 	}
 	defer opencodeServer.Stop()
 
-	model := ui.NewModel(cfg, globalStore, agentMgr, opencodeServer, filterProjectID)
+	updateChecker := update.NewChecker(version)
+	model := ui.NewModel(cfg, globalStore, agentMgr, opencodeServer, filterProjectID, updateChecker)
 
 	defer model.Cleanup()
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,130 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	githubRepo = "TechDufus/openkanban"
+	apiTimeout = 5 * time.Second
+)
+
+type InstallMethod int
+
+const (
+	InstallUnknown InstallMethod = iota
+	InstallHomebrew
+	InstallGo
+)
+
+// Release represents a GitHub release
+type Release struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// CheckResult contains the result of an update check
+type CheckResult struct {
+	UpdateAvailable bool
+	LatestVersion   string
+	CurrentVersion  string
+	ReleaseURL      string
+	InstallMethod   InstallMethod
+	Error           error
+}
+
+// UpdateHint returns a user-friendly update command based on install method
+func (r CheckResult) UpdateHint() string {
+	switch r.InstallMethod {
+	case InstallHomebrew:
+		return "brew upgrade openkanban"
+	case InstallGo:
+		return "go install github.com/techdufus/openkanban@latest"
+	default:
+		return r.ReleaseURL
+	}
+}
+
+// DetectInstallMethod determines how openkanban was installed
+func DetectInstallMethod() InstallMethod {
+	exe, err := os.Executable()
+	if err != nil {
+		return InstallUnknown
+	}
+
+	if strings.Contains(exe, "Cellar") || strings.Contains(exe, "linuxbrew") {
+		return InstallHomebrew
+	}
+
+	if strings.Contains(exe, "/go/bin") {
+		return InstallGo
+	}
+
+	return InstallUnknown
+}
+
+// Checker provides update checking functionality
+type Checker struct {
+	CurrentVersion string
+}
+
+// NewChecker creates a new update checker for the given version
+func NewChecker(currentVersion string) *Checker {
+	return &Checker{CurrentVersion: currentVersion}
+}
+
+// Check compares the current version against the latest GitHub release.
+// Returns immediately if current version is "dev" (development build).
+func (c *Checker) Check() CheckResult {
+	return Check(c.CurrentVersion)
+}
+
+// Check compares the current version against the latest GitHub release.
+func Check(currentVersion string) CheckResult {
+	result := CheckResult{
+		CurrentVersion: currentVersion,
+	}
+
+	if currentVersion == "dev" || currentVersion == "" {
+		return result
+	}
+
+	client := &http.Client{Timeout: apiTimeout}
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", githubRepo)
+
+	resp, err := client.Get(url)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to check for updates: %w", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		result.Error = fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		return result
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		result.Error = fmt.Errorf("failed to parse release info: %w", err)
+		return result
+	}
+
+	result.LatestVersion = release.TagName
+	result.ReleaseURL = release.HTMLURL
+	result.InstallMethod = DetectInstallMethod()
+
+	current := strings.TrimPrefix(currentVersion, "v")
+	latest := strings.TrimPrefix(release.TagName, "v")
+
+	if latest != current && latest != "" {
+		result.UpdateAvailable = true
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary
- Checks GitHub releases API on app startup and notifies users when a newer version is available
- Detects install method (Homebrew vs go install) and shows the appropriate update command in the notification

Example notifications:
- Homebrew: `Update v0.0.7 available: brew upgrade openkanban`
- Go install: `Update v0.0.7 available: go install github.com/techdufus/openkanban@latest`