### PR TITLE
fix: sort project lists to prevent UI flickering

### DIFF
--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/techdufus/openkanban/internal/config"
 )
@@ -130,5 +131,8 @@ func (r *ProjectRegistry) List() []*Project {
 	for _, p := range r.Projects {
 		result = append(result, p)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
 	return result
 }

--- a/internal/project/tickets.go
+++ b/internal/project/tickets.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/techdufus/openkanban/internal/board"
@@ -278,6 +279,9 @@ func (g *GlobalTicketStore) Projects() []*Project {
 	for _, p := range g.projects {
 		result = append(result, p)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
 	return result
 }
 


### PR DESCRIPTION
Go map iteration order is non-deterministic, causing project lists to reorder randomly on each render. This made it nearly impossible to select projects as they moved under the cursor.

Added `sort.Slice()` by project name to both `Projects()` and `List()` methods for stable ordering.

Fixes #67