### PR TITLE
fix: prevent stale session ID from failing first spawn

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2198,10 +2198,12 @@ func (m *Model) prepareSpawn(ticket *board.Ticket, proj *project.Project, agentC
 				args = []string{"attach", opencodeServer.URL(), "--session", sessionID}
 			} else {
 				args = []string{worktreePath, "--port", fmt.Sprintf("%d", agentPort)}
-				if isNewSession && promptTemplate != "" {
-					prompt := agent.BuildContextPrompt(promptTemplate, ticket)
-					if prompt != "" {
-						args = append(args, "-p", prompt)
+				if isNewSession {
+					if promptTemplate != "" {
+						prompt := agent.BuildContextPrompt(promptTemplate, ticket)
+						if prompt != "" {
+							args = append(args, "-p", prompt)
+						}
 					}
 				} else if sessionID != "" {
 					args = append(args, "--session", sessionID)


### PR DESCRIPTION
When spawning a new opencode session, `FindOpencodeSession()` could return a stale session ID from a previous run. The code was passing `--session <staleID>` even for new sessions, causing opencode to exit immediately if that session no longer exists.

Changed the logic so `--session` is only passed when resuming an existing session (`isNewSession = false`), never for first-time spawns.

Fixes #68