### PR TITLE
fix: improve form scroll behavior and show full fields on focus

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1074,17 +1074,6 @@ func (m *Model) handleTicketForm(msg tea.KeyMsg, isEdit bool) (tea.Model, tea.Cm
 		m.showAddProjectForm = false
 		return m, nil
 
-	case "ctrl+u", "pgup":
-		m.formScrollOffset -= m.formViewportHeight() / 2
-		if m.formScrollOffset < 0 {
-			m.formScrollOffset = 0
-		}
-		return m, nil
-
-	case "ctrl+d", "pgdown":
-		m.formScrollOffset += m.formViewportHeight() / 2
-		return m, nil
-
 	case "tab":
 		if m.showAddProjectForm && m.addProjectPath.Value() != "" {
 			m.createProjectFromPath()


### PR DESCRIPTION
## Summary

- Auto-scroll now shows the entire field when tabbing, not just the start line
- Tracks field end lines to properly calculate field heights
- Accounts for scroll indicator space in viewport calculations
- Removes ctrl+u/d keyboard scroll shortcuts (Tab + mouse wheel is sufficient)
- Fixes scroll indicator count accuracy